### PR TITLE
Replace Str::camel() with Str::studly()

### DIFF
--- a/src/CollectionMacrosServiceProvider.php
+++ b/src/CollectionMacrosServiceProvider.php
@@ -21,7 +21,7 @@ class CollectionMacrosServiceProvider extends ServiceProvider
             if (! Collection::hasMacro($macro)) {
                 $class = "Werxe\\Laravel\\CollectionMacros\\Macros\\{$macro}";
 
-                Collection::macro($macro, app($class)());
+                Collection::macro(Str::lower($macro), app($class)());
             }
         }
     }

--- a/src/CollectionMacrosServiceProvider.php
+++ b/src/CollectionMacrosServiceProvider.php
@@ -16,7 +16,7 @@ class CollectionMacrosServiceProvider extends ServiceProvider
         $macros = glob(__DIR__.'/Macros/*.php');
 
         foreach ($macros as $macroPath) {
-            $macro = Str::camel(pathinfo($macroPath, PATHINFO_FILENAME));
+            $macro = Str::studly(pathinfo($macroPath, PATHINFO_FILENAME));
 
             if (! Collection::hasMacro($macro)) {
                 $class = "Werxe\\Laravel\\CollectionMacros\\Macros\\{$macro}";


### PR DESCRIPTION
`Str::camel()` does not work as expected with a single word.

Str::camel('abc') --> 'abc'
Str::camel('abc_def') --> 'abcDef'

Str::studly('abc') --> 'Abc'.
Str::studly('abc_def') --> 'AbcDef'.

A fresh install from `werxe/laravel-collection-macros` on Linux env will fail because files are case sensitive.